### PR TITLE
Correctly remove orphaned css modules

### DIFF
--- a/css.js
+++ b/css.js
@@ -109,8 +109,21 @@ if(isProduction) {
 					var cssReload = loader.import("live-reload", { name: "$css" });
 					Promise.resolve(cssReload).then(function(reload){
 						loader.import(load.name).then(function(){
+							var wasReloaded = false;
 							reload.once(load.name, function(){
+								wasReloaded = true;
 								head.removeChild(style);
+							});
+							// We need this code for orphaned modules. We set
+							// a flag to see if the css was reloaded, if not
+							// we know we can remove it after the reload
+							// cycle is complete.
+							reload.dispose(load.name, function(){
+								reload.once("!cycleComplete", function(){
+									if(!wasReloaded) {
+										head.removeChild(style);
+									}
+								});
 							});
 						});
 					});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "funcunit": "^3.0.0",
-    "steal": "^0.11.0-pre.0",
+    "steal": "^0.12.0-pre.0",
     "steal-qunit": "0.0.4",
     "testee": "^0.2.0",
 	"live-reload-testing": "^1.0.0"

--- a/test/live-orphan/index.html
+++ b/test/live-orphan/index.html
@@ -1,0 +1,7 @@
+<script>
+	steal = {
+		configDependencies: ["live-reload"]
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/live-orphan/main"></script>
+<div id="app"></div>

--- a/test/live-orphan/main.js
+++ b/test/live-orphan/main.js
@@ -1,0 +1,2 @@
+require('./style.css!');
+require('./other.css!');

--- a/test/live-orphan/other.css
+++ b/test/live-orphan/other.css
@@ -1,0 +1,7 @@
+body {
+	background: red;
+}
+
+#app {
+	height: 20px;
+}

--- a/test/live-orphan/style.css
+++ b/test/live-orphan/style.css
@@ -1,0 +1,7 @@
+body {
+	background: blue;
+}
+
+#app {
+	height: 10px;
+}

--- a/test/test-live-reload.js
+++ b/test/test-live-reload.js
@@ -65,3 +65,36 @@ QUnit.test("reloading css that has been server side rendered works", function(){
 
 	F("#app").exists().height(20, "The height is now correct");
 });
+
+QUnit.module("live-reload removes orphaned modules", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//live-orphan/index.html", function(){
+			done();
+		});
+	},
+	teardown: function(assert){
+		var done = assert.async();
+		liveReloadTest.reset().then(function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("the orphaned module's css is removed", function(){
+	F("style").exists("the initial style is on the page");
+	F("#app").exists().height(20, "The height is correct initially");
+
+	F(function(){
+		var address = "test/live-orphan/main.js";
+		var content = "require('./style.css!');";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Changing the css was not successful");
+			QUnit.start();
+		});
+	});
+
+	F("#app").exists().height(10, "The height is now correct because other.css was removed from the page");
+});
+


### PR DESCRIPTION
With css during a live-reload we wait until the new `<style>` is
inserted into the page before removing the old `<style>`. The reason for
this is so that there is no flash of the css being temporarily missing.

So to make orphan removal work we need to use a flag that lets us know
if the css module is reloaded. it works like there:

1. A `wasReloaded` flag is initially false.
2. We listen for when the css module is reloaded.
3. If it is reloaded the `wasReloaded` flag gets set to true.
4. Meanwhile we are also listening for the css module's disposal. If it
is disposed it **might** be reloaded, this is why we need the flag, we
don't know if it will be reloaded or not.
5. We then listen to the cycleComplete event to know that all reloading
is complete, at which time we can check the flag. If the flag is still
`false` we know the module was disposed by never reloaded, and therefore
is an orphan that can be removed.

Fixes #7