### PR TITLE
In dev, use the renderingLoader.baseURL when rewriting urls()

### DIFF
--- a/css.js
+++ b/css.js
@@ -73,8 +73,17 @@ if(isProduction) {
 		load.metadata.execute = function(){
 			var liveReloadEnabled = loader.has("live-reload");
 			var source = load.source+"/*# sourceURL="+load.address+" */";
+			var address = load.address;
+
+			// If on the server use the renderingLoader to use the correct
+			// address when rewriting url()s.
+			if(loader.renderingLoader) {
+				var href = load.address.substr(loader.baseURL.length);
+				address = steal.joinURIs(loader.renderingLoader.baseURL, href);
+			}
+
 			source = source.replace(/url\(['"]?([^'"\)]*)['"]?\)/g, function(whole, part) {
-				return "url(" + steal.joinURIs( load.address, part) + ")";
+				return "url(" + steal.joinURIs(address, part) + ")";
 			});
 
 			if(load.source && typeof document !== "undefined") {

--- a/test/rendering-loader/config.js
+++ b/test/rendering-loader/config.js
@@ -1,0 +1,6 @@
+"format cjs";
+
+var loader = require("@loader");
+
+loader.renderingLoader = loader.clone();
+loader.renderingLoader.baseURL = "http://example.com/app/";

--- a/test/rendering-loader/index.html
+++ b/test/rendering-loader/index.html
@@ -1,0 +1,9 @@
+<script>
+	steal = {
+		configDependencies: [
+			"test/rendering-loader/config"
+		]
+	};
+</script>
+<script src="../../node_modules/steal/steal.js" main="test/rendering-loader/main"></script>
+<div>hello world</div>

--- a/test/rendering-loader/main.js
+++ b/test/rendering-loader/main.js
@@ -1,0 +1,1 @@
+require("./style.css!");

--- a/test/rendering-loader/style.css
+++ b/test/rendering-loader/style.css
@@ -1,0 +1,14 @@
+@font-face {
+  font-family: 'foo';
+  src: url('../fonts/foo.eot');
+  src: url('../fonts/foo.eot?#iefix') format('embedded-opentype'),
+       url('../fonts/foo.eot.woff2') format('woff2'),
+       url('../fonts/foo.woff') format('woff'),
+       url('../fonts/foo.ttf') format('truetype'),
+       url('../fonts/foo.svg#bar') format('svg');
+}
+
+body {
+	background: blue;
+	font-family: foo;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,13 @@ QUnit.module("basics", {
 QUnit.test("basics works", function(){
 	F("style").exists("the style was added to the page");
 });
+
+QUnit.module("renderingLoader", {
+	setup: function(){
+		F.open("//rendering-loader/index.html");
+	}
+});
+
+QUnit.test("is used when rewriting url()s", function(){
+	F("style").exists().text(/example\.com\/app/, "The renderingLoader's base url is http://example.com/app and this was used to rewrite font urls() correctly");
+});


### PR DESCRIPTION
We do this in production mode already to know how to attach the
`<link>`, in development we need the same behavior when rewriting
url()s.