### PR TITLE
Get to work in ie8

### DIFF
--- a/test/basics/index.html
+++ b/test/basics/index.html
@@ -1,1 +1,3 @@
+<!doctype html>
+<meta http-equiv="x-ua-compatible" content="IE=Edge"/>
 <script src="../../node_modules/steal/steal.js" main="test/basics/basics"></script>

--- a/test/rendering-loader/index.html
+++ b/test/rendering-loader/index.html
@@ -1,3 +1,5 @@
+<!doctype html>
+<meta http-equiv="x-ua-compatible" content="IE=Edge"/>
 <script>
 	steal = {
 		configDependencies: [

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,5 @@
+<!doctype html>
+<meta http-equiv="x-ua-compatible" content="IE=Edge"/>
 <title>done-css tests</title>
 <script>
 	FuncUnit = { frameMode: true };


### PR DESCRIPTION
This updates css.js to work in ie8. Fixes are to switch loader.import to
loader["import"] and including a function that traverses the head
looking for a matching load object.

Fixes #16 