### PR TITLE
Know when to add a style by making reloaded styles as dirty

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@
 
 A CSS plugin for DoneJS projects.
 
+## Install
+
+To use this plugin in a DoneJS project just install it:
+
+```js
+npm install done-css --save
+```
+
+## Contributing
+
+To setup your dev environment:
+
+1. Clone and fork this repo.
+2. Run `npm install`.
+3. Open `test/test.html` in your browser. Everything should pass.
+4. Run `npm test`. Everything should pass.
+5. Run `npm run-script build`. Everything should build ok.
+To publish:
+
+1. Update the version number in package.json
+2. Update the version number in `test/live-ssr/index.html`
+3. Commit and push this to master
+4. Tag it `git tag v0.2.0`. Push the tag `git push origin --tags`.
+
 ## License
 
 MIT

--- a/css.js
+++ b/css.js
@@ -102,7 +102,7 @@ if(isProduction) {
 				}
 
 				var style = getExistingAsset(load, head);
-				if(!style || liveReloadEnabled) {
+				if(!style || style.__isDirty) {
 					style = document.createElement('style')
 
 					// make source load relative to the current page
@@ -131,6 +131,7 @@ if(isProduction) {
 							// we know we can remove it after the reload
 							// cycle is complete.
 							reload.dispose(load.name, function(){
+								style.__isDirty = true;
 								reload.once("!cycleComplete", function(){
 									if(!wasReloaded) {
 										head.removeChild(style);

--- a/test/live-ssr/index.html
+++ b/test/live-ssr/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<style asset-id="test/live-ssr/style.css!done-css@1.1.6#css">
+	<style asset-id="test/live-ssr/style.css!done-css@1.1.11#css">
 		body {
 			background: blue;
 		}

--- a/test/test-live-reload.js
+++ b/test/test-live-reload.js
@@ -51,11 +51,31 @@ QUnit.module("live-reload with ssr", {
 });
 
 QUnit.test("reloading css that has been server side rendered works", function(){
-	F("style").exists("the initial style is on the page");
+	F("style").size(1, "the initial style is on the page");
 
 	F(function(){
 		var address = "test/live-ssr/basics.js";
 		var content = "require('./other.css!');";
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Changing the css was not successful");
+			QUnit.start();
+		});
+	});
+
+	F("#app").exists().height(20, "The height is now correct");
+});
+
+QUnit.test("Updating the exists styles works", function(){
+	F("style").size(1, "The initial style is on the page");
+
+	F(function(){
+		var address = "test/live-ssr/style.css";
+		var content = "body {\n" +
+			"background: red;\n" +
+			"}\n" +
+			"#app {\n" +
+			"height: 20px;\n}";
 
 		liveReloadTest.put(address, content).then(null, function(){
 			QUnit.ok(false, "Changing the css was not successful");
@@ -97,4 +117,3 @@ QUnit.test("the orphaned module's css is removed", function(){
 
 	F("#app").exists().height(10, "The height is now correct because other.css was removed from the page");
 });
-


### PR DESCRIPTION
During live-reload we need this order to happen:

1. New version of the css is appended to the head.
2. Old version of the css is removed from the head.

This prevents FOUC.

However live-reload works in this order:

1. Old modules are disposed.
2. New modules are imported.

As you can see, this is the opposite order from what we want with css.

This is essentially what makes css live-reload harder than for other
plugins.

To make the situation harder we have server side rendering where a
`<style>` will already be in th page.  In this case we want to not
insert a new style.

So, the question is how do we know whether to insert a new style or not?
If we are live-reloading we want to. If we are loading for the first
time with ssr enabled we don't want to.

The solution is to never insert a new `<style>` if an existing one is
there, **unless** that style is marked dirty. We mark it dirty when it
is being disposed.

Fixes #23