### PR TITLE
Refactors live-reload support to be simplified.

### DIFF
--- a/test/live-ssr/index.html
+++ b/test/live-ssr/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<style asset-id="test/live-ssr/style.css!done-css@1.1.11#css">
+	<style asset-id="test/live-ssr/style.css!done-css@1.1.12#css">
 		body {
 			background: blue;
 		}

--- a/test/test-live-reload.js
+++ b/test/test-live-reload.js
@@ -35,6 +35,7 @@ QUnit.test("removing css works", function(){
    F("#app").exists().height(20, "The height is now correct");
 });
 
+
 QUnit.module("live-reload with ssr", {
 	setup: function(assert){
 		var done = assert.async();


### PR DESCRIPTION
This change refactors our live-reload support to make it simplified.
Instead of listening to several different events we do something more
simple:

Listen for the module to be disposed. When this happens listen for
the reload cycle to be complete. When it is complete we can remove the
old style. This is safe because:

1) We always want to remove the old style. So if a css module is
reloaded we always want to remove the old one.
2) By always removing the old we ensure orphans are removed as well.

The key feature of this refactor is that we no longer listen for the
reload event for the css module. We don't care if that css module is
reloaded or not. We only care that 1) it is disposed 2) the reload cycle
finishes (at some point).