### PR TITLE
Use System.liveReloadInstalled

### DIFF
--- a/css.js
+++ b/css.js
@@ -74,7 +74,7 @@ if(isProduction) {
 
 		load.metadata.deps = [];
 		load.metadata.execute = function(){
-			var liveReloadEnabled = loader.has("live-reload");
+			var liveReloadEnabled = loader.liveReloadInstalled || loader.has("live-reload");
 			var source = load.source+"/*# sourceURL="+load.address+" */";
 			var address = load.address;
 


### PR DESCRIPTION
live-reload sets this as a global so it's a better way to check that
live-reload is on than `loader.has("live-reload");`