### PR TITLE
Account for trailing slash in renderingLoader

### DIFF
--- a/css.js
+++ b/css.js
@@ -12,6 +12,11 @@ function getExistingAsset(load, head){
 	return val && val[0];
 }
 
+function addSlash(url) {
+	var hasSlash = url[url.length - 1] === "/";
+	return url + (hasSlash ? "" : "/");
+}
+
 var isNode = typeof process === "object" &&
 	{}.toString.call(process) === "[object process]";
 
@@ -42,7 +47,7 @@ if(isProduction) {
 			if(loader.renderingLoader) {
 				var baseURL = loader.renderingLoader.baseURL;
 				if(baseURL.indexOf("http") === 0) {
-					href = baseURL + cssFile.replace("dist/", "");
+					href = addSlash(baseURL) + cssFile.replace("dist/", "");
 				}
 			}
 
@@ -83,7 +88,8 @@ if(isProduction) {
 			// address when rewriting url()s.
 			if(loader.renderingLoader) {
 				var href = load.address.substr(loader.baseURL.length);
-				address = steal.joinURIs(loader.renderingLoader.baseURL, href);
+				var baseURL = addSlash(loader.renderingLoader.baseURL);
+				address = steal.joinURIs(baseURL, href);
 			}
 
 			source = source.replace(/url\(['"]?([^'"\)]*)['"]?\)/g, function(whole, part) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "funcunit": "^3.0.0",
-    "steal": "^0.12.0-pre.0",
+    "steal": "^0.13.0",
     "steal-qunit": "0.0.4",
     "testee": "^0.2.0",
 	"live-reload-testing": "^1.0.0"

--- a/test/basics/dist/bundles/test/basics/basics.js
+++ b/test/basics/dist/bundles/test/basics/basics.js
@@ -270,7 +270,7 @@ define('npm-extension', function (require, exports, module) {
     exports.includeInBuild = true;
     exports.addExtension = function (System) {
         var oldNormalize = System.normalize;
-        System.normalize = function (name, parentName, parentAddress) {
+        System.normalize = function (name, parentName, parentAddress, pluginNormalize) {
             if (parentName && utils.path.isRelative(name) && !utils.moduleName.isNpm(parentName)) {
                 return oldNormalize.call(this, name, parentName, parentAddress);
             }
@@ -294,7 +294,7 @@ define('npm-extension', function (require, exports, module) {
                 parsedModuleName.version = refPkg.version;
                 parsedModuleName.packageName = refPkg.name;
                 parsedModuleName.modulePath = utils.pkg.main(refPkg);
-                return oldNormalize.call(this, utils.moduleName.create(parsedModuleName), parentName, parentAddress);
+                return oldNormalize.call(this, utils.moduleName.create(parsedModuleName), parentName, parentAddress, pluginNormalize);
             }
             if (depPkg) {
                 parsedModuleName.version = depPkg.version;
@@ -305,16 +305,16 @@ define('npm-extension', function (require, exports, module) {
                 if (refPkg.system && refPkg.system.map && typeof refPkg.system.map[moduleName] === 'string') {
                     moduleName = refPkg.system.map[moduleName];
                 }
-                return oldNormalize.call(this, moduleName, parentName, parentAddress);
+                return oldNormalize.call(this, moduleName, parentName, parentAddress, pluginNormalize);
             } else {
                 if (depPkg === this.npmPaths.__default) {
                     var localName = parsedModuleName.modulePath ? parsedModuleName.modulePath + (parsedModuleName.plugin ? parsedModuleName.plugin : '') : utils.pkg.main(depPkg);
-                    return oldNormalize.call(this, localName, parentName, parentAddress);
+                    return oldNormalize.call(this, localName, parentName, parentAddress, pluginNormalize);
                 }
                 if (refPkg.browser && refPkg.browser[name]) {
-                    return oldNormalize.call(this, refPkg.browser[name], parentName, parentAddress);
+                    return oldNormalize.call(this, refPkg.browser[name], parentName, parentAddress, pluginNormalize);
                 }
-                return oldNormalize.call(this, name, parentName, parentAddress);
+                return oldNormalize.call(this, name, parentName, parentAddress, pluginNormalize);
             }
         };
         var oldLocate = System.locate;

--- a/test/live-ssr/index.html
+++ b/test/live-ssr/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<style asset-id="test/live-ssr/style.css!done-css@1.1.14#css">
+	<style asset-id="test/live-ssr/style.css!done-css@1.1.15#css">
 		body {
 			background: blue;
 		}

--- a/test/rendering-loader/config.js
+++ b/test/rendering-loader/config.js
@@ -3,4 +3,4 @@
 var loader = require("@loader");
 
 loader.renderingLoader = loader.clone();
-loader.renderingLoader.baseURL = "http://example.com/app/";
+loader.renderingLoader.baseURL = "http://example.com/app";


### PR DESCRIPTION
The renderLoader.baseURL is used to determine the baseURL for production
CSS when deployed to a CDN. This fixes a bug where we were not
accounting for whether a trailing slash is included.