### PR TITLE
Traverse dom to find asset-ids

### DIFF
--- a/css.js
+++ b/css.js
@@ -4,24 +4,31 @@ var loader = require("@loader");
 var register = loader.has("asset-register") ?
 	loader.get("asset-register")["default"] : function(){};
 
-var globalDoc = (function () {
-	if ( typeof canSsr !== "undefined" && canSsr.globalDocument ) {
-		return canSsr.globalDocument;
-	}
-
+function globalDoc() {
 	if(typeof doneSsr !== "undefined" && doneSsr.globalDocument) {
 		return doneSsr.globalDocument;
 	}
 
 	return typeof document === "undefined" ? undefined : document;
-});
+}
 
 function getExistingAsset(load, head){
-	var selector = "[asset-id='" + load.name + "']";
-	var val = (typeof jQuery !== 'undefined') ?
-						jQuery(selector) :
-						globalDoc().querySelectorAll(selector);
-	return val && val[0];
+	var doc = globalDoc();
+
+	if(doc.querySelectorAll) {
+		var selector = "[asset-id='" + load.name + "']";
+		var val = doc.querySelectorAll(selector);
+		return val && val[0];
+	} else {
+		var els = doc.getElementsByTagName("*"), el;
+
+		for(var i = 0, len = els.length; i < len; i++) {
+			el = els[i];
+			if(el.getAttribute("asset-id") === load.name) {
+				return el;
+			}
+		}
+	}
 }
 
 function addSlash(url) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "done-css",
-  "version": "2.0.3",
+  "version": "2.1.0-pre.0",
   "description": "A CSS plugin, for css",
   "main": "css.js",
   "scripts": {

--- a/test/ssr/config.js
+++ b/test/ssr/config.js
@@ -6,6 +6,6 @@ if ( iframeDoc.document ) {
   iframeDoc = iframeDoc.document;
 }
 
-canSsr = {
+doneSsr = {
   globalDocument: iframeDoc
 };


### PR DESCRIPTION
This updates the method with which we traverse the dom to find
`asset-id` attributes. No longer use jquery (it's not available usually)
and just do some simple traversal. Makes this compatible with can3
