### PR TITLE
Properly register for SSR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ script: npm test
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: latest

--- a/css.js
+++ b/css.js
@@ -68,7 +68,7 @@ proto.registerSSR = function(){
 		};
 	}
 
-	this.getSSRRegister()(this.name, "css", cb);
+	this.getSSRRegister()(this.load.name, "css", cb);
 };
 
 proto.updateURLs = function(){
@@ -170,6 +170,9 @@ if(loader.isEnv("production")) {
 			if(getDocument()) {
 				css.injectStyle();
 				css.setupLiveReload(loader, load.name);
+			}
+			if(isNode && !isNW) {
+				css.registerSSR();
 			}
 
 			return loader.newModule({

--- a/test/css_test.js
+++ b/test/css_test.js
@@ -46,3 +46,5 @@ QUnit.module("loading modules with deps", function(hooks){
 
 	});
 });
+
+require("./test-ssr");

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -6,6 +6,7 @@ require("done-css");
 
 exports.clone = clone;
 exports.removeAddedStyles = removeAddedStyles;
+exports.fakeBeingInNode = fakeBeingInNode;
 
 function clone(){
 	var name = "done-css@" + pkg.version + "#css";
@@ -31,4 +32,21 @@ function removeAddedStyles() {
 		}
 	}
 
+}
+
+function fakeBeingInNode() {
+	process = {};
+	var ts = Object.prototype.toString;
+	Object.prototype.toString = function(){
+		if(this === process) {
+			return "[object process]";
+		}
+		return ts.call(this);
+	};
+
+	return function(){
+		var global = steal.loader.global;
+		delete global.process;
+		Object.prototype.toString = ts;
+	};
 }

--- a/test/test-ssr.js
+++ b/test/test-ssr.js
@@ -1,0 +1,40 @@
+var QUnit = require("steal-qunit");
+var helpers = require("./test-helpers");
+require("done-css");
+
+QUnit.module("SSR", {
+	setup: function(){
+		this.resetEnv = helpers.fakeBeingInNode();
+	},
+	teardown: function(){
+		helpers.removeAddedStyles();
+		this.resetEnv();
+	}
+});
+
+QUnit.test("Registers in development mode", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withModule("app@1.0.0#app.css!done-css", "body {}")
+		.loader;
+
+	loader.set("asset-register", loader.newModule({
+		default: function(moduleName, type, cb){
+			assert.equal(moduleName, "app@1.0.0#app.css!done-css");
+			assert.equal(type, "css");
+			assert.equal(typeof cb, "function");
+		},
+		__useDefault: true
+	}));
+
+	loader["import"]("app/app.css!done-css")
+	.then(function(){
+		done();
+	}, done);
+});


### PR DESCRIPTION
This fixes SSR registration so that we do it in development and properly
pass through the moduleName to SSR's asset-register module.

Closes #48.