### PR TITLE
Add steal-css to steal's plugins config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     },
     "map": {
       "$css": "done-css"
-    }
+    },
+    "plugins": [
+      "steal-css"
+    ]
   },
   "devDependencies": {
     "funcunit": "^3.0.0",


### PR DESCRIPTION
This ensures that steal-css' configuration is loaded before done-css, and prevents a race condition for configuration.