### PR TITLE
The cacheVersion option doesn't work in SSR because...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ To use this plugin in a DoneJS project just install it:
 npm install done-css --save
 ```
 
+## Features
+
+### renderingCacheVersion
+
+When server-side rendering with [done-ssr](https://github.com/donejs/done-ssr) and using the [cache busting](https://stealjs.com/docs/config.cacheVersion.html) extension you need to specify the `renderingCacheVersion` property in your config. You might do so like this:
+
+```js
+const ssr = require("done-ssr");
+
+const render = ssr({
+	renderingCacheVersion: 99
+});
+```
+
+Doing this will result in the cache version number appearing in the server-rendered `<link>` elements.
+
 ## Contributing
 
 To setup your dev environment:

--- a/css.js
+++ b/css.js
@@ -50,6 +50,14 @@ proto.updateProductionHref = function(){
 		}
 	}
 
+	if(loader.renderingCacheVersion) {
+		var cacheKey = loader.cacheKey || "version";
+		var cacheKeyVersion  = cacheKey + "=" + loader.renderingCacheVersion;
+		if(href.indexOf(cacheKeyVersion) === -1) {
+			href = href + (href.indexOf("?") === -1 ? "?" : "&") + cacheKeyVersion;
+		}
+	}
+
 	this.href = href;
 };
 
@@ -148,6 +156,7 @@ var isNW = (function(){
 		return false;
 	}
 })();
+
 var isElectron = isNode && !!process.versions.electron;
 
 if(loader.isEnv("production")) {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -17,7 +17,6 @@ function clone(){
 	var sSource = steal.loader.getModuleLoad(sName).source;
 
 	return helpers.clone()
-		//.withModule("@steal", "module.exports = steal")
 		.withModule("done-css", source)
 		.withModule("steal-css", sSource);
 }


### PR DESCRIPTION
That is applied for the code running on the server. We need to specify
what is actually rendered to HTML.

We have a similar option, `renderingBaseURL` for changing the baseURL
that is output in the `<link>`. This adds `renderingCacheVersion` for
adding the cache version query param.

Closes #66